### PR TITLE
Print out databases directory contents in cronjob

### DIFF
--- a/docker/src/entrypoint.sh
+++ b/docker/src/entrypoint.sh
@@ -15,6 +15,8 @@ check_config() {
 show_config() {
     echo "CVD-Update configuration..."
     cvd config show --config $CVD_DIR/config.json
+    echo "Current contents in $CVD_DIR/databases directory..."
+    ls -al $CVD_DIR/databases
 }
 
 # CVD Database Functions

--- a/openshift/app.cronjob.yaml
+++ b/openshift/app.cronjob.yaml
@@ -37,7 +37,7 @@ objects:
             template: "${REPO_NAME}-updater-template"
         spec:
           activeDeadlineSeconds: 600
-          backoffLimit: 1
+          backoffLimit: 0
           completions: 1
           parallelism: 1
           template:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
- Adds an `ls -al` of the databases directory during cronjob execution
- Ensure the cronjob doesn't end up double-running when there are failures
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2101](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2101)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
