### PR TITLE
fix databases path

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -49,3 +49,25 @@ Once you have the mirror running, you can visit <http://localhost:8080> to see w
 ```txt
 DatabaseMirror http://localhost:8080
 ```
+
+### Run (dev & troubleshooting)
+
+some helpful commands for developing and troubleshooting:
+
+```sh
+# build image
+
+# run container and get into bash
+docker run --name clamav --rm -it clamav-mirror bash
+
+# run status
+sh entrypoint.sh status
+
+# check config file and paths
+cat /mnt/cvdupdate/config.json
+ls -laht /mnt/cvdupdate/{logs,databases}
+
+# run update and check files
+sh entrypoint.sh update
+ls -laht /mnt/cvdupdate/databases/*.cvd
+```

--- a/docker/src/entrypoint.sh
+++ b/docker/src/entrypoint.sh
@@ -10,6 +10,10 @@ check_config() {
         cvd config set --config $CVD_DIR/config.json --dbdir $CVD_DIR/databases --logdir $CVD_DIR/logs
         echo "CVD configuration created..."
     fi
+    if [ ! -e $CVD_DIR/databases ]; then
+      echo "creating $CVD_DIR/databases folder"
+      mkdir -p $CVD_DIR/databases
+    fi
 }
 
 show_config() {

--- a/docker/src/entrypoint.sh
+++ b/docker/src/entrypoint.sh
@@ -11,7 +11,7 @@ check_config() {
         echo "CVD configuration created..."
     fi
     if [ ! -e $CVD_DIR/databases ]; then
-      echo "creating $CVD_DIR/databases folder"
+      echo "Creating $CVD_DIR/databases folder"
       mkdir -p $CVD_DIR/databases
     fi
 }


### PR DESCRIPTION
databases path wasn't being created during initialtization or even during the first run by cvd config set.

Current contents in /mnt/cvdupdate/databases directory...
ls: /mnt/cvdupdate/databases: No such file or directory

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
