### PR TITLE
Add Net Binding

### DIFF
--- a/openshift/app.dc.yaml
+++ b/openshift/app.dc.yaml
@@ -71,7 +71,8 @@ objects:
               image: "${IMAGE_REGISTRY}/${NAMESPACE}/${REPO_NAME}-app:latest"
               securityContext:
                 capabilities:
-                  add: ["NET_BIND_SERVICE"]
+                  add:
+                    - NET_BIND_SERVICE
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 tcpSocket:

--- a/openshift/app.dc.yaml
+++ b/openshift/app.dc.yaml
@@ -69,6 +69,9 @@ objects:
           containers:
             - name: app
               image: "${IMAGE_REGISTRY}/${NAMESPACE}/${REPO_NAME}-app:latest"
+              securityContext:
+                capabilities:
+                  add: ["NET_BIND_SERVICE"]
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 tcpSocket:


### PR DESCRIPTION
# Description
Add Net Binding to the deployed Images so they can properly run Caddy

This is required to fix an error on initial startup where the deployed pods are unable to invoke the caddy binary.

`./entrypoint.sh: line 41: /usr/sbin/caddy: Operation not permitted`

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes - Could not find any tests to run
- [ ] I have added tests that prove my fix is effective or that my feature works - Could not find any tests to run
- [ ] I have added necessary documentation (if appropriate)

## Further comments
This fix was provided by Om Mishra from Rocketchat and I wanted to commit it here to help others from hitting the same issue.
